### PR TITLE
Refactor clearance session retrieval to use promise

### DIFF
--- a/src/api/scraper/scrapeClearance.ts
+++ b/src/api/scraper/scrapeClearance.ts
@@ -66,6 +66,8 @@ export async function scrapeClearance(req: TypedRequest, res: Response) {
 
         page.setDefaultTimeout(data.timeout ?? 60_000);
 
+        const sessionPromise = getClearance(page, browser, data, browserLogger);
+
         if (data.method === "GET") {
             await page.goto(data.url, { waitUntil: "networkidle2" });
         } else if (data.method === "POST") {
@@ -84,7 +86,7 @@ export async function scrapeClearance(req: TypedRequest, res: Response) {
             );
         }
 
-        const session = await getClearance(page, browser, data, browserLogger);
+        const session = await sessionPromise;
 
         browserLogger.info("Successfully obtained clearance");
 


### PR DESCRIPTION
Instead of this:
await page.goto(data.url, { waitUntil: "networkidle2" }); const session = await getClearance(page, browser, data, browserLogger);

Do this to avoid a potential race condition:
const clearancePromise = getClearance(page, browser, data, browserLogger); await page.goto(data.url, { waitUntil: "networkidle2" }); const session = await clearancePromise;

Because if the Cloudflare challenge completes and sends its final response between line 70 and line 129, those responses would be missed because the listeners aren't yet active.